### PR TITLE
Create fluid dynamic physprop

### DIFF
--- a/Assets/Prefabs/TestMap.prefab
+++ b/Assets/Prefabs/TestMap.prefab
@@ -2149,6 +2149,7 @@ MonoBehaviour:
   interp_delay: 0.02
   inactive_delay: 0.5
   velocity: {x: 0, y: 0, z: 0}
+  networkChildren: []
   networkParentLocalPosition: {x: 0, y: 0, z: 0}
   networkParentLocalRotation: {x: 0, y: 0, z: 0, w: 0}
   debug_mode: 0
@@ -19260,6 +19261,7 @@ MonoBehaviour:
   interp_delay: 0.02
   inactive_delay: 0.5
   velocity: {x: 0, y: 0, z: 0}
+  networkChildren: []
   networkParentLocalPosition: {x: 0, y: 0, z: 0}
   networkParentLocalRotation: {x: 0, y: 0, z: 0, w: 0}
   debug_mode: 0
@@ -20156,6 +20158,7 @@ MonoBehaviour:
   interp_delay: 0.02
   inactive_delay: 0.5
   velocity: {x: 0, y: 0, z: 0}
+  networkChildren: []
   networkParentLocalPosition: {x: 0, y: 0, z: 0}
   networkParentLocalRotation: {x: 0, y: 0, z: 0, w: 0}
   debug_mode: 0
@@ -21060,6 +21063,7 @@ MonoBehaviour:
   interp_delay: 0.02
   inactive_delay: 0.5
   velocity: {x: 0, y: 0, z: 0}
+  networkChildren: []
   networkParentLocalPosition: {x: 0, y: 0, z: 0}
   networkParentLocalRotation: {x: 0, y: 0, z: 0, w: 0}
   debug_mode: 0
@@ -29128,6 +29132,7 @@ MonoBehaviour:
   interp_delay: 0.02
   inactive_delay: 0.5
   velocity: {x: 0, y: 0, z: 0}
+  networkChildren: []
   networkParentLocalPosition: {x: 0, y: 0, z: 0}
   networkParentLocalRotation: {x: 0, y: 0, z: 0, w: 0}
   debug_mode: 0
@@ -29181,14 +29186,15 @@ GameObject:
   m_Component:
   - component: {fileID: 183}
   - component: {fileID: 253}
+  - component: {fileID: 289}
   - component: {fileID: 284}
   - component: {fileID: 455}
   - component: {fileID: 322}
-  - component: {fileID: 289}
   - component: {fileID: 452}
   - component: {fileID: 451}
   - component: {fileID: 456}
   - component: {fileID: 454}
+  - component: {fileID: 3257998212214638199}
   m_Layer: 0
   m_Name: Cube (6)
   m_TagString: Untagged
@@ -29247,6 +29253,22 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+--- !u!54 &289
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 73}
+  serializedVersion: 2
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0
+  m_UseGravity: 1
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_Constraints: 80
+  m_CollisionDetection: 0
 --- !u!33 &284
 MeshFilter:
   m_ObjectHideFlags: 0
@@ -29549,22 +29571,6 @@ MeshCollider:
   m_Convex: 1
   m_CookingOptions: 14
   m_Mesh: {fileID: 0}
---- !u!54 &289
-Rigidbody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 73}
-  serializedVersion: 2
-  m_Mass: 1
-  m_Drag: 0
-  m_AngularDrag: 0
-  m_UseGravity: 1
-  m_IsKinematic: 0
-  m_Interpolate: 0
-  m_Constraints: 80
-  m_CollisionDetection: 0
 --- !u!114 &452
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -29621,9 +29627,26 @@ MonoBehaviour:
   interp_delay: 0.02
   inactive_delay: 0.5
   velocity: {x: 0, y: 0, z: 0}
+  networkChildren: []
   networkParentLocalPosition: {x: 0, y: 0, z: 0}
   networkParentLocalRotation: {x: 0, y: 0, z: 0, w: 0}
   debug_mode: 0
+--- !u!114 &3257998212214638199
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 73}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bd0d2b006f92c4151ab973429076b6b0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  rigidbody: {fileID: 0}
+  effectiveVolume: 0
+  fallingFrictionOnly: 1
+  airFriction: {x: 0, y: 10, z: 0}
 --- !u!1001 &5489729563154158534
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -29631,6 +29654,11 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 179}
     m_Modifications:
+    - target: {fileID: 6131574351243999541, guid: 3389058717a25a7488115996621fb330,
+        type: 3}
+      propertyPath: m_Name
+      value: BoltCutters Variant
+      objectReference: {fileID: 0}
     - target: {fileID: 6131574351244092693, guid: 3389058717a25a7488115996621fb330,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -29685,11 +29713,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6131574351243999541, guid: 3389058717a25a7488115996621fb330,
-        type: 3}
-      propertyPath: m_Name
-      value: BoltCutters Variant
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 3389058717a25a7488115996621fb330, type: 3}

--- a/Assets/Scripts/Entities/PhysicsProps/FluidDynamic.cs
+++ b/Assets/Scripts/Entities/PhysicsProps/FluidDynamic.cs
@@ -1,0 +1,29 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using MLAPI;
+
+[AddComponentMenu("PhysicsProps/FluidDynamic")]
+[RequireComponent(typeof(Rigidbody))]
+public class FluidDynamic : PhysicsProp {
+    public const float density_air = 1f;
+    public const float density_water = 800f;
+    public float effectiveVolume = 0f;
+    public bool fallingFrictionOnly = false;
+    public Vector3 airFriction = new Vector3(0.1f, 1f, 0.1f);
+
+    private void ApplyAirFriction() {
+        Vector3 computedAirFriction = airFriction;
+        if (fallingFrictionOnly && rigidbody.velocity.y > 0f) computedAirFriction.y = 0f;
+        rigidbody.AddForce(-transform.TransformDirection(Vector3.Scale(transform.InverseTransformDirection(rigidbody.velocity), computedAirFriction)));
+    }
+
+    private void ApplyBuoyantForce() {
+        rigidbody.AddForce(-Physics.gravity * effectiveVolume * density_air);
+    }
+
+    private void FixedUpdate() {
+        ApplyAirFriction();
+        ApplyBuoyantForce();
+    }
+}

--- a/Assets/Scripts/Entities/PhysicsProps/FluidDynamic.cs.meta
+++ b/Assets/Scripts/Entities/PhysicsProps/FluidDynamic.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bd0d2b006f92c4151ab973429076b6b0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Player/Physics/PhysicsPropHandler.cs
+++ b/Assets/Scripts/Player/Physics/PhysicsPropHandler.cs
@@ -11,7 +11,8 @@ public class PhysicsPropHandler : NetworkedBehaviour {
     private void Awake() {
         plugins = new Dictionary<Type, PhysicsPlugin>() {
             {typeof(Pushable), new Pusher(context: this)},
-            {typeof(Grabable), new Grabber(context: this)}
+            {typeof(Grabable), new Grabber(context: this)},
+            {typeof(FluidDynamic), new FluidDynamicHandler(context: this)}
         };
 
         foreach (PhysicsPlugin plugin in plugins.Values) {

--- a/Assets/Scripts/Player/Physics/Plugins/FluidDynamicHandler.cs
+++ b/Assets/Scripts/Player/Physics/Plugins/FluidDynamicHandler.cs
@@ -1,0 +1,26 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class FluidDynamicHandler : PhysicsPlugin {
+    public FluidDynamicHandler(PhysicsPropHandler context) : base(context) { }
+
+    private void ApplyAirFriction(Transform transform, Vector3 airFriction, bool fallingFrictionOnly) {
+        Vector3 computedAirFriction = airFriction;
+        if (fallingFrictionOnly && player.GetVelocity().y > 0f) computedAirFriction.y = 0f;
+        player.Accelerate(-transform.TransformDirection(Vector3.Scale(transform.InverseTransformDirection(player.GetVelocity()), computedAirFriction)));
+    }
+
+    private void ApplyBuoyantForce(float effectiveVolume) {
+        player.Accelerate(-Physics.gravity * effectiveVolume * FluidDynamic.density_air);
+    }
+
+    public override void FixedUpdate() {
+        if (!isOwner) return;
+        FluidDynamic flchild = GetComponentInNetworkedChildren<FluidDynamic>();
+        if (flchild != null) {
+            ApplyAirFriction(flchild.transform, flchild.airFriction, flchild.fallingFrictionOnly);
+            ApplyBuoyantForce(flchild.effectiveVolume);
+        }
+    }
+}

--- a/Assets/Scripts/Player/Physics/Plugins/FluidDynamicHandler.cs.meta
+++ b/Assets/Scripts/Player/Physics/Plugins/FluidDynamicHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 01a2769fbb63447918b40cb4220a0bfe
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Player/Physics/Plugins/PhysicsPlugin.cs
+++ b/Assets/Scripts/Player/Physics/Plugins/PhysicsPlugin.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 using MLAPI;
 
@@ -49,4 +50,10 @@ public class PhysicsPlugin : ComponentPlugin {
 
     // A return value of true "hides" the regular use behavior of the player controller
     public virtual bool OnUse(PhysicsProp prop) { return false; }
+
+    public T GetComponentInNetworkedChildren<T>() {
+        T childcomp = context.GetComponentInChildren<T>();
+        if (childcomp != null) return childcomp;
+        return moving_player.networkChildren.Select((child) => child.GetComponentInChildren<T>()).FirstOrDefault();
+    }
 }

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,1 +1,1 @@
-m_EditorVersion: 2018.3.2f1
+m_EditorVersion: 2018.3.3f1


### PR DESCRIPTION
This adds fluid dynamic physics props. These currently only have air friction (with optional falling friction only mode) and buoyant forces. When the player is the parent of a fluid dynamic object the player will also experience the effects of the object. This means that when the player grabs the "floaty block" they will start floating too.

This also adds networkChildren to the networkedobjecttransform so that the clients can determine if they have child physics props that are separate moving objects.