### PR TITLE
Improve wind and fluid dynamic

### DIFF
--- a/Assets/Prefabs/TestMap.prefab
+++ b/Assets/Prefabs/TestMap.prefab
@@ -55,6 +55,7 @@ Transform:
   - {fileID: 250}
   - {fileID: 255}
   - {fileID: 4118103701815890262}
+  - {fileID: 1748152414823908338}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -9036,7 +9037,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8233d90336aea43098adf6dbabd606a2, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_MeshFormatVersion: 0
+  m_MeshFormatVersion: 1
   m_Faces: []
   m_SharedVertices: []
   m_SharedTextures: []
@@ -14346,7 +14347,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8233d90336aea43098adf6dbabd606a2, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_MeshFormatVersion: 0
+  m_MeshFormatVersion: 1
   m_Faces: []
   m_SharedVertices: []
   m_SharedTextures: []
@@ -25835,7 +25836,8 @@ MonoBehaviour:
   rigidbody: {fileID: 0}
   effectiveVolume: 0
   fallingFrictionOnly: 1
-  airFriction: {x: 0, y: 10, z: 0}
+  oneWayFriction: 1
+  airFriction: {x: 4, y: 4, z: 4}
   current_wind: {fileID: 0}
 --- !u!1 &126
 GameObject:
@@ -25969,7 +25971,7 @@ GameObject:
   - component: {fileID: 3927047829525109407}
   - component: {fileID: 6822185878352957922}
   m_Layer: 2
-  m_Name: Cube
+  m_Name: Wind Updraft
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -26246,17 +26248,9 @@ MonoBehaviour:
   m_PreserveMeshAssetOnDestroy: 0
   assetGuid: 
   m_IsSelectable: 1
-  m_SelectedFaces: 04000000
-  m_SelectedEdges:
-  - a: 16
-    b: 17
-  - a: 18
-    b: 16
-  - a: 17
-    b: 19
-  - a: 19
-    b: 18
-  m_SelectedVertices: 10000000110000001200000013000000
+  m_SelectedFaces: 
+  m_SelectedEdges: []
+  m_SelectedVertices: 
 --- !u!64 &1797239198029629478
 MeshCollider:
   m_ObjectHideFlags: 0
@@ -26301,3 +26295,123 @@ MonoBehaviour:
   isLocal: 1
   constantForceValue: {x: 0, y: 0, z: 0}
   constantVelocityValue: {x: 0, y: 20, z: 0}
+  windCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1.0023689
+      inSlope: -0.0022309779
+      outSlope: -0.0022309779
+      tangentMode: 34
+      weightedMode: 0
+      inWeight: 0
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 0.9496228
+      value: 1.0002503
+      inSlope: 0.002653021
+      outSlope: 0.002653021
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.10861031
+      outWeight: 0.70219713
+    - serializedVersion: 3
+      time: 0.9999752
+      value: 0.000008946285
+      inSlope: -0.009439458
+      outSlope: -0.009439458
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 1
+      outWeight: 0
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+--- !u!1 &4660006117170157575
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1748152414823908338}
+  - component: {fileID: 8048691357227175156}
+  - component: {fileID: 5475544892435483663}
+  m_Layer: 2
+  m_Name: Wind Tunnel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1748152414823908338
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4660006117170157575}
+  m_LocalRotation: {x: 0.5039542, y: -0.12693968, z: 0.26415002, w: 0.8124909}
+  m_LocalPosition: {x: 7.5, y: 2.25, z: 51.5}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 246}
+  m_RootOrder: 27
+  m_LocalEulerAnglesHint: {x: 62.372, y: 7.4300003, z: 40.521004}
+--- !u!136 &8048691357227175156
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4660006117170157575}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  m_Radius: 12
+  m_Height: 60
+  m_Direction: 1
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!114 &5475544892435483663
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4660006117170157575}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 14a709bfc6efdf6449e44b0c90c9235f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  rigidbody: {fileID: 0}
+  isConstant: 1
+  isLocal: 1
+  constantForceValue: {x: 0, y: 0, z: 0}
+  constantVelocityValue: {x: 0, y: 30, z: 0}
+  windCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 34
+      weightedMode: 0
+      inWeight: 0
+      outWeight: 0
+    - serializedVersion: 3
+      time: 1
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 34
+      weightedMode: 0
+      inWeight: 0
+      outWeight: 0
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4

--- a/Assets/Scenes/SceneBuilder.unity
+++ b/Assets/Scenes/SceneBuilder.unity
@@ -118,7 +118,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh-49592
+  m_Name: pb_Mesh-33546
   serializedVersion: 9
   m_SubMeshes:
   - serializedVersion: 2
@@ -278,7 +278,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh-49928
+  m_Name: pb_Mesh-33784
   serializedVersion: 9
   m_SubMeshes:
   - serializedVersion: 2
@@ -438,7 +438,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh-50474
+  m_Name: pb_Mesh-33568
   serializedVersion: 9
   m_SubMeshes:
   - serializedVersion: 2
@@ -598,7 +598,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh-49576
+  m_Name: pb_Mesh-33510
   serializedVersion: 9
   m_SubMeshes:
   - serializedVersion: 2
@@ -758,7 +758,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh-49676
+  m_Name: pb_Mesh-33538
   serializedVersion: 9
   m_SubMeshes:
   - serializedVersion: 2
@@ -918,7 +918,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh-49590
+  m_Name: pb_Mesh-33544
   serializedVersion: 9
   m_SubMeshes: []
   m_Shapes:
@@ -1068,7 +1068,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh-49568
+  m_Name: pb_Mesh-33768
   serializedVersion: 9
   m_SubMeshes:
   - serializedVersion: 2
@@ -1228,7 +1228,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh-49926
+  m_Name: pb_Mesh-33780
   serializedVersion: 9
   m_SubMeshes:
   - serializedVersion: 2
@@ -1388,7 +1388,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh-49670
+  m_Name: pb_Mesh-33522
   serializedVersion: 9
   m_SubMeshes:
   - serializedVersion: 2
@@ -1548,7 +1548,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh-50024
+  m_Name: pb_Mesh-33910
   serializedVersion: 9
   m_SubMeshes:
   - serializedVersion: 2
@@ -1708,7 +1708,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh-49578
+  m_Name: pb_Mesh-33512
   serializedVersion: 9
   m_SubMeshes:
   - serializedVersion: 2
@@ -1868,7 +1868,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh-49668
+  m_Name: pb_Mesh-33518
   serializedVersion: 9
   m_SubMeshes: []
   m_Shapes:
@@ -2018,7 +2018,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh-49674
+  m_Name: pb_Mesh-33536
   serializedVersion: 9
   m_SubMeshes:
   - serializedVersion: 2
@@ -2178,7 +2178,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh-49760
+  m_Name: pb_Mesh-33558
   serializedVersion: 9
   m_SubMeshes:
   - serializedVersion: 2
@@ -2338,7 +2338,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh-50026
+  m_Name: pb_Mesh-33912
   serializedVersion: 9
   m_SubMeshes:
   - serializedVersion: 2
@@ -2498,7 +2498,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh-49672
+  m_Name: pb_Mesh-33524
   serializedVersion: 9
   m_SubMeshes:
   - serializedVersion: 2
@@ -2658,7 +2658,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh-49764
+  m_Name: pb_Mesh-33562
   serializedVersion: 9
   m_SubMeshes:
   - serializedVersion: 2
@@ -2818,7 +2818,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh-49930
+  m_Name: pb_Mesh-33786
   serializedVersion: 9
   m_SubMeshes:
   - serializedVersion: 2
@@ -2979,50 +2979,10 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
-    - target: {fileID: 395, guid: 417c56e68ced9a3449a11082afd376c9, type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: 251303384}
     - target: {fileID: 51, guid: 417c56e68ced9a3449a11082afd376c9, type: 3}
       propertyPath: m_Name
       value: TestMap
       objectReference: {fileID: 0}
-    - target: {fileID: 402, guid: 417c56e68ced9a3449a11082afd376c9, type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: 1553759999}
-    - target: {fileID: 403, guid: 417c56e68ced9a3449a11082afd376c9, type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: 894404208}
-    - target: {fileID: 404, guid: 417c56e68ced9a3449a11082afd376c9, type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: 563353048}
-    - target: {fileID: 407, guid: 417c56e68ced9a3449a11082afd376c9, type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: 932523423}
-    - target: {fileID: 406, guid: 417c56e68ced9a3449a11082afd376c9, type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: 142610692}
-    - target: {fileID: 405, guid: 417c56e68ced9a3449a11082afd376c9, type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: 623144750}
-    - target: {fileID: 408, guid: 417c56e68ced9a3449a11082afd376c9, type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: 1040614087}
-    - target: {fileID: 409, guid: 417c56e68ced9a3449a11082afd376c9, type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: 1633818126}
-    - target: {fileID: 410, guid: 417c56e68ced9a3449a11082afd376c9, type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: 956982099}
     - target: {fileID: 246, guid: 417c56e68ced9a3449a11082afd376c9, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
@@ -3067,30 +3027,6 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 397, guid: 417c56e68ced9a3449a11082afd376c9, type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: 314318112}
-    - target: {fileID: 398, guid: 417c56e68ced9a3449a11082afd376c9, type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: 107434977}
-    - target: {fileID: 396, guid: 417c56e68ced9a3449a11082afd376c9, type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: 1287469330}
-    - target: {fileID: 399, guid: 417c56e68ced9a3449a11082afd376c9, type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: 1449827644}
-    - target: {fileID: 400, guid: 417c56e68ced9a3449a11082afd376c9, type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: 1539107622}
-    - target: {fileID: 401, guid: 417c56e68ced9a3449a11082afd376c9, type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: 1413931147}
     - target: {fileID: 343, guid: 417c56e68ced9a3449a11082afd376c9, type: 3}
       propertyPath: m_Mesh
       value: 
@@ -3383,10 +3319,6 @@ PrefabInstance:
       propertyPath: m_Mesh
       value: 
       objectReference: {fileID: 830833117}
-    - target: {fileID: 574, guid: 417c56e68ced9a3449a11082afd376c9, type: 3}
-      propertyPath: m_MeshFormatVersion
-      value: 1
-      objectReference: {fileID: 0}
     - target: {fileID: 388, guid: 417c56e68ced9a3449a11082afd376c9, type: 3}
       propertyPath: m_Mesh
       value: 
@@ -3471,7 +3403,15 @@ PrefabInstance:
       propertyPath: m_Mesh
       value: 
       objectReference: {fileID: 251303384}
+    - target: {fileID: 395, guid: 417c56e68ced9a3449a11082afd376c9, type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 251303384}
     - target: {fileID: 357, guid: 417c56e68ced9a3449a11082afd376c9, type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 1287469330}
+    - target: {fileID: 396, guid: 417c56e68ced9a3449a11082afd376c9, type: 3}
       propertyPath: m_Mesh
       value: 
       objectReference: {fileID: 1287469330}
@@ -3479,11 +3419,15 @@ PrefabInstance:
       propertyPath: m_Mesh
       value: 
       objectReference: {fileID: 314318112}
-    - target: {fileID: 586, guid: 417c56e68ced9a3449a11082afd376c9, type: 3}
-      propertyPath: m_MeshFormatVersion
-      value: 1
-      objectReference: {fileID: 0}
+    - target: {fileID: 397, guid: 417c56e68ced9a3449a11082afd376c9, type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 314318112}
     - target: {fileID: 359, guid: 417c56e68ced9a3449a11082afd376c9, type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 107434977}
+    - target: {fileID: 398, guid: 417c56e68ced9a3449a11082afd376c9, type: 3}
       propertyPath: m_Mesh
       value: 
       objectReference: {fileID: 107434977}
@@ -3491,7 +3435,15 @@ PrefabInstance:
       propertyPath: m_Mesh
       value: 
       objectReference: {fileID: 1553759999}
+    - target: {fileID: 402, guid: 417c56e68ced9a3449a11082afd376c9, type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 1553759999}
     - target: {fileID: 364, guid: 417c56e68ced9a3449a11082afd376c9, type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 894404208}
+    - target: {fileID: 403, guid: 417c56e68ced9a3449a11082afd376c9, type: 3}
       propertyPath: m_Mesh
       value: 
       objectReference: {fileID: 894404208}
@@ -3499,10 +3451,28 @@ PrefabInstance:
       propertyPath: m_Mesh
       value: 
       objectReference: {fileID: 1633818126}
+    - target: {fileID: 409, guid: 417c56e68ced9a3449a11082afd376c9, type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 1633818126}
     - target: {fileID: 371, guid: 417c56e68ced9a3449a11082afd376c9, type: 3}
       propertyPath: m_Mesh
       value: 
       objectReference: {fileID: 956982099}
+    - target: {fileID: 410, guid: 417c56e68ced9a3449a11082afd376c9, type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 956982099}
+    - target: {fileID: 5675409927194188539, guid: 417c56e68ced9a3449a11082afd376c9,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 145974766}
+    - target: {fileID: 1797239198029629478, guid: 417c56e68ced9a3449a11082afd376c9,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 145974766}
     - target: {fileID: 341, guid: 417c56e68ced9a3449a11082afd376c9, type: 3}
       propertyPath: m_Mesh
       value: 
@@ -3531,7 +3501,15 @@ PrefabInstance:
       propertyPath: m_Mesh
       value: 
       objectReference: {fileID: 1449827644}
+    - target: {fileID: 399, guid: 417c56e68ced9a3449a11082afd376c9, type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 1449827644}
     - target: {fileID: 361, guid: 417c56e68ced9a3449a11082afd376c9, type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 1539107622}
+    - target: {fileID: 400, guid: 417c56e68ced9a3449a11082afd376c9, type: 3}
       propertyPath: m_Mesh
       value: 
       objectReference: {fileID: 1539107622}
@@ -3539,7 +3517,15 @@ PrefabInstance:
       propertyPath: m_Mesh
       value: 
       objectReference: {fileID: 1413931147}
+    - target: {fileID: 401, guid: 417c56e68ced9a3449a11082afd376c9, type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 1413931147}
     - target: {fileID: 365, guid: 417c56e68ced9a3449a11082afd376c9, type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 563353048}
+    - target: {fileID: 404, guid: 417c56e68ced9a3449a11082afd376c9, type: 3}
       propertyPath: m_Mesh
       value: 
       objectReference: {fileID: 563353048}
@@ -3547,7 +3533,15 @@ PrefabInstance:
       propertyPath: m_Mesh
       value: 
       objectReference: {fileID: 142610692}
+    - target: {fileID: 406, guid: 417c56e68ced9a3449a11082afd376c9, type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 142610692}
     - target: {fileID: 369, guid: 417c56e68ced9a3449a11082afd376c9, type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 1040614087}
+    - target: {fileID: 408, guid: 417c56e68ced9a3449a11082afd376c9, type: 3}
       propertyPath: m_Mesh
       value: 
       objectReference: {fileID: 1040614087}
@@ -3555,20 +3549,18 @@ PrefabInstance:
       propertyPath: m_Mesh
       value: 
       objectReference: {fileID: 623144750}
+    - target: {fileID: 405, guid: 417c56e68ced9a3449a11082afd376c9, type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 623144750}
     - target: {fileID: 368, guid: 417c56e68ced9a3449a11082afd376c9, type: 3}
       propertyPath: m_Mesh
       value: 
       objectReference: {fileID: 932523423}
-    - target: {fileID: 5675409927194188539, guid: 417c56e68ced9a3449a11082afd376c9,
-        type: 3}
+    - target: {fileID: 407, guid: 417c56e68ced9a3449a11082afd376c9, type: 3}
       propertyPath: m_Mesh
       value: 
-      objectReference: {fileID: 145974766}
-    - target: {fileID: 1797239198029629478, guid: 417c56e68ced9a3449a11082afd376c9,
-        type: 3}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: 145974766}
+      objectReference: {fileID: 932523423}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 417c56e68ced9a3449a11082afd376c9, type: 3}
 --- !u!43 &1255167480
@@ -3577,7 +3569,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh-49570
+  m_Name: pb_Mesh-33770
   serializedVersion: 9
   m_SubMeshes:
   - serializedVersion: 2
@@ -3737,7 +3729,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh-49728
+  m_Name: pb_Mesh-33540
   serializedVersion: 9
   m_SubMeshes:
   - serializedVersion: 2
@@ -3897,7 +3889,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh-49666
+  m_Name: pb_Mesh-33506
   serializedVersion: 9
   m_SubMeshes:
   - serializedVersion: 2
@@ -4057,7 +4049,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh-49584
+  m_Name: pb_Mesh-33520
   serializedVersion: 9
   m_SubMeshes:
   - serializedVersion: 2
@@ -4217,7 +4209,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh-49924
+  m_Name: pb_Mesh-33778
   serializedVersion: 9
   m_SubMeshes:
   - serializedVersion: 2
@@ -4377,7 +4369,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh-49586
+  m_Name: pb_Mesh-33526
   serializedVersion: 9
   m_SubMeshes:
   - serializedVersion: 2
@@ -4537,7 +4529,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh-49920
+  m_Name: pb_Mesh-33774
   serializedVersion: 9
   m_SubMeshes:
   - serializedVersion: 2
@@ -4697,7 +4689,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh-49726
+  m_Name: pb_Mesh-33772
   serializedVersion: 9
   m_SubMeshes:
   - serializedVersion: 2
@@ -4857,7 +4849,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh-49922
+  m_Name: pb_Mesh-33776
   serializedVersion: 9
   m_SubMeshes:
   - serializedVersion: 2
@@ -5017,7 +5009,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh-49758
+  m_Name: pb_Mesh-33556
   serializedVersion: 9
   m_SubMeshes:
   - serializedVersion: 2
@@ -5177,7 +5169,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh-49574
+  m_Name: pb_Mesh-33508
   serializedVersion: 9
   m_SubMeshes:
   - serializedVersion: 2
@@ -5337,7 +5329,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh-49762
+  m_Name: pb_Mesh-33560
   serializedVersion: 9
   m_SubMeshes:
   - serializedVersion: 2
@@ -5497,7 +5489,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh-49582
+  m_Name: pb_Mesh-33516
   serializedVersion: 9
   m_SubMeshes:
   - serializedVersion: 2
@@ -5657,7 +5649,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh-49580
+  m_Name: pb_Mesh-33514
   serializedVersion: 9
   m_SubMeshes:
   - serializedVersion: 2

--- a/Assets/Scripts/Entities/PhysicsProps/FluidDynamic.cs
+++ b/Assets/Scripts/Entities/PhysicsProps/FluidDynamic.cs
@@ -9,7 +9,9 @@ public class FluidDynamic : PhysicsProp {
     public const float density_air = 1f;
     public const float density_water = 800f;
     public float effectiveVolume = 0f;
+    // Enable the two bools below for good player movement with a fluid dynamic object
     public bool fallingFrictionOnly = false;
+    public bool oneWayFriction = false;
     public Vector3 airFriction = new Vector3(0.1f, 1f, 0.1f);
     public Wind current_wind;
     private string WIND_TIMER;
@@ -20,11 +22,21 @@ public class FluidDynamic : PhysicsProp {
         utils.CreateTimer(WIND_TIMER, 0.1f).setFinished();
     }
 
-    public Vector3 CalculateAirFriction(Vector3 velocity) {
+    public Vector3 CalculateAirFriction(Vector3 velocity, Vector3? desiredDirection = null) {
+        if (desiredDirection == null) desiredDirection = Vector3.up;
         Vector3 computedAirFriction = airFriction;
-        Vector3 relativeVelocity = velocity - GetWindVelocity();
-        if (fallingFrictionOnly && relativeVelocity.y > 0f) computedAirFriction.y = 0f;
-        return -transform.TransformDirection(Vector3.Scale(transform.InverseTransformDirection(relativeVelocity), computedAirFriction));
+        Vector3 windVelocity = GetWindVelocity();
+        Vector3 relativeVelocity = velocity - windVelocity;
+        Vector3 relativeLocalVelocity = transform.InverseTransformDirection(relativeVelocity);
+        if (fallingFrictionOnly && relativeLocalVelocity.y > 0f) computedAirFriction.y = 0f;
+        // If we have "one way friction" disable x/z friction if the following are true:
+        //   * We are either moving faster than the wind, or are moving nearly perpendicular to it
+        //   * We are attempting to move in the same direction as the wind / moving normally outside of wind
+        if (oneWayFriction && (Vector3.Dot(relativeVelocity, windVelocity) >= 0 || Mathf.Abs(Vector3.Dot(desiredDirection.Value, windVelocity.normalized)) < 0.1f) && Vector3.Dot(relativeVelocity, desiredDirection.Value) > 0f) {
+            computedAirFriction.x = 0f;
+            computedAirFriction.z = 0f;
+        }
+        return -transform.TransformDirection(Vector3.Scale(relativeLocalVelocity, computedAirFriction));
     }
 
     public Vector3 CalculateBuoyantForce() {

--- a/Assets/Scripts/Entities/PhysicsProps/Wind.cs
+++ b/Assets/Scripts/Entities/PhysicsProps/Wind.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using System.Linq;
 using MLAPI;
 
 [AddComponentMenu("PhysicsProps/Wind")]
@@ -10,6 +11,15 @@ public class Wind : PhysicsProp {
     public bool isLocal;
     public Vector3 constantForceValue;
     public Vector3 constantVelocityValue;
+    public AnimationCurve windCurve;
+    private Collider windBox;
+    private (float, float) curveRange;
+
+    protected override void Awake() {
+        base.Awake();
+        windBox = GetComponent<Collider>();
+        curveRange = (windCurve.keys.First().time, windCurve.keys.Last().time);
+    }
 
     public Vector3 GetForceAtPosition(Vector3 position) {
         Vector3 calculatedForce = Vector3.zero;
@@ -19,11 +29,33 @@ public class Wind : PhysicsProp {
         return calculatedForce;
     }
 
+    private Vector3 CalculateVelocityWithCurve(Vector3 base_velocity, Vector3 position) {
+        float vertical_extent;
+        float vertical_pos;
+        Vector3 base_vel_dir = base_velocity.normalized;
+        switch (windBox) {
+            case BoxCollider bc:
+                vertical_extent = Vector3.Dot(transform.up * bc.size.y, base_vel_dir);
+                vertical_pos = Mathf.Clamp(Vector3.Dot(position - (bc.center - (transform.up * bc.size.y / 2f)), base_vel_dir), 0f, vertical_extent);
+                break;
+            case CapsuleCollider cc:
+                vertical_extent = Vector3.Dot(transform.up * cc.height, base_vel_dir);
+                vertical_pos = Mathf.Clamp(Vector3.Dot(position - (cc.center - (transform.up * cc.height / 2f)), base_vel_dir), 0f, vertical_extent);
+                break;
+            default:
+                vertical_extent = Vector3.Dot(windBox.bounds.extents, base_vel_dir) * 2f;
+                vertical_pos = Mathf.Clamp(Vector3.Dot(position - windBox.bounds.min, base_vel_dir), 0f, vertical_extent);
+                break;
+        }
+        float curveVal = curveRange.Item1 + (curveRange.Item2 - curveRange.Item1) * (vertical_pos / vertical_extent);
+        return base_velocity * windCurve.Evaluate(curveVal);
+    }
+
     public Vector3 GetWindVelocityAtPosition(Vector3 position) {
         Vector3 calculatedVel = Vector3.zero;
-        // Only constant wind velocity/force is supported for now
         if (isConstant) calculatedVel = constantVelocityValue;
         if (isLocal) calculatedVel = transform.TransformDirection(calculatedVel);
+        calculatedVel = CalculateVelocityWithCurve(base_velocity: calculatedVel, position: position);
         return calculatedVel;
     }
 

--- a/Assets/Scripts/Player/Physics/Plugins/FluidDynamicHandler.cs
+++ b/Assets/Scripts/Player/Physics/Plugins/FluidDynamicHandler.cs
@@ -8,7 +8,9 @@ public class FluidDynamicHandler : PhysicsPlugin {
     private void HandleFluidDynamicChildren() {
         FluidDynamic flchild = GetComponentInNetworkedChildren<FluidDynamic>();
         if (flchild != null) {
-            player.Accelerate(flchild.CalculateAirFriction(player.GetVelocity()));
+            player.Accelerate(flchild.CalculateAirFriction(
+                velocity: player.GetVelocity(),
+                desiredDirection: player.GetMoveVector()));
             player.Accelerate(flchild.CalculateBuoyantForce());
         }
     }


### PR DESCRIPTION
This lets you configure the wind using an animation curve to control the strength based on the players position in the direction of the wind. This also makes the fluid dynamic objects have a "oneWayFriction" mode that disables friction in certain scenarios where the player wants to move in a certain direction with a fluid dynamic prop that would normally have friction in that direction.